### PR TITLE
[Update] Build to Thunderbird 52.4 and build against GNOME 32.6

### DIFF
--- a/org.mozilla.Thunderbird.json
+++ b/org.mozilla.Thunderbird.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.mozilla.Thunderbird",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "thunderbird",
     "rename-icon": "thunderbird",
@@ -112,8 +112,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://ftp.mozilla.org/pub/thunderbird/releases/52.1.0/source/thunderbird-52.1.0.source.tar.xz",
-                    "sha256": "c33ca35b6acd1a0dc0d0f4b1df16745a33144c5d3d3715fe05454a5e9eefd48b"
+                    "url": "https://ftp.mozilla.org/pub/thunderbird/releases/52.4.0/source/thunderbird-52.4.0.source.tar.xz",
+                    "sha256": "7f57b5b4d4ec42b04afcff8327abc2d3c6185c0bcc1ad138825d021a2d3f578c"
                 }
             ]
         }

--- a/thunderbird-Makefile
+++ b/thunderbird-Makefile
@@ -1,4 +1,4 @@
-VERSION = 52.1.0
+VERSION = 52.4.0
 CFLAGS += -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2
 CXXFLAGS += -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2
 


### PR DESCRIPTION
I thought I'd bump Thunderbird to a later version since you hadn't. I don't know how you feel about me using a different runtime version. The reason I did was I'm on Fedora Atomic Workstation and have `3.26.1`, so I thought I'd just use `32.6` to build against. I'm not too familiar with flatpak, it seemed to compile + run just fine. If there's anything you'd like me to change before possibly merging, just tell me.